### PR TITLE
TEST: integration test for new and initialised

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,10 @@ parallel = true
 source =
     shopyo
     .
+omit =
+    # omit anything in a .local directory anywhere
+    */.tox/*
+    */instance/*
 
 [report]
 show_missing = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,7 @@
 [pytest]
 env_files =
     .test.prod.env
+
+markers =
+    cli_unit: unit cli tests
+    cli_integration: marks tests as integrations tests which are slow (deselect with '-m "not cli_intergration"')

--- a/shopyo/api/tests/conftest.py
+++ b/shopyo/api/tests/conftest.py
@@ -4,6 +4,25 @@ All pytest fixtures local only to the api/tests are placed here
 """
 import pytest
 import os
+import shutil
+import tempfile
+
+
+@pytest.fixture
+def cleandir():
+    old_cwd = os.getcwd()
+    newpath = tempfile.mkdtemp()
+    os.chdir(newpath)
+    yield
+    os.chdir(old_cwd)
+    shutil.rmtree(newpath)
+
+
+@pytest.fixture
+def restore_cwd():
+    old = os.getcwd()
+    yield
+    os.chdir(old)
 
 
 @pytest.fixture
@@ -39,18 +58,21 @@ def fake_foo_proj(tmp_path):
         built in pytest fixture which will provide a temporary directory unique
         to the test invocation, created in the base temporary directory.
     """
+    # create the tmp_path/foo/foo
     project_path = tmp_path / "foo" / "foo"
     project_path.mkdir(parents=True)
+    # create the static and modules inside foo/foo
     static_path = project_path / "static"
     module_path = project_path / "modules"
+    static_path.mkdir()
+    module_path.mkdir()
+    # create the dummy boxes and modules
     demo_path = module_path / "box__bizhelp/demo/demo.py"
     foo_path = module_path / "box__default/foo/static/foo.css"
     zoo_path = module_path / "box__default/zoo/static/zoo.css"
     foozoo_path = module_path / "box__default/foozoo/foozoo.py"
     bar_path = module_path / "bar/static/bar.css"
     baz_path = module_path / "baz/model/baz.py"
-    static_path.mkdir()
-    module_path.mkdir()
     demo_path.parent.mkdir(parents=True)
     foo_path.parent.mkdir(parents=True)
     zoo_path.parent.mkdir(parents=True)
@@ -63,5 +85,9 @@ def fake_foo_proj(tmp_path):
     foozoo_path.write_text("foozoo")
     bar_path.write_text("bar")
     baz_path.write_text("baz")
+    # save cwd and chage to test project directory
+    old = os.getcwd()
     os.chdir(project_path)
     yield project_path
+    # restore old cwd directory
+    os.chdir(old)

--- a/shopyo/api/tests/test_cli.py
+++ b/shopyo/api/tests/test_cli.py
@@ -4,6 +4,8 @@ from click.testing import CliRunner
 from shopyo.api.cli import cli
 from shopyo.api.constants import SEP_CHAR, SEP_NUM
 
+pytestmark = pytest.mark.cli_unit
+
 
 @pytest.fixture(scope='session')
 def cli_runner():
@@ -17,6 +19,7 @@ def cli_runner():
     return cli_main
 
 
+@pytest.mark.usefixtures("restore_cwd")
 class TestCliCreateBox:
     """test the create_box command line api function"""
 
@@ -46,6 +49,7 @@ class TestCliCreateBox:
         assert expected in result.output
 
 
+@pytest.mark.usefixtures("restore_cwd")
 @pytest.mark.order("last")
 class TestCliClean:
     """tests the clean command line api function"""
@@ -360,6 +364,7 @@ class TestCliClean:
     # TODO: add test_clean for MySQL to see if tables dropped @rehmanis
 
 
+@pytest.mark.usefixtures("restore_cwd")
 class TestCliNew:
 
     @pytest.mark.parametrize("proj,parent", [("", "foo"), ("bar", "")])

--- a/shopyo/api/tests/test_cli_integration.py
+++ b/shopyo/api/tests/test_cli_integration.py
@@ -1,0 +1,67 @@
+from shutil import copytree
+import subprocess
+import pytest
+import sys
+import os
+from shopyo import __version__
+
+
+pytestmark = pytest.mark.cli_integration
+
+
+@pytest.mark.usefixtures("restore_cwd")
+def test_initialise_after_new(tmp_path):
+    """run shopyo new inside a tmp directory foo,
+    create a venv, install the shopyo.tar.gz dependencies,
+    run `shopyo new` and then run `shopyo initialise`.
+    """
+
+    # go one level up to the cwd so we are are the root where
+    # setup.py exits
+    os.chdir("../")
+    # create the dist folder with shoypo-<version>.tar.gz file
+    subprocess.check_call([sys.executable, "setup.py", "sdist"])
+    # store all path names to be used later
+    dist_path = os.path.join(os.getcwd(), "dist")
+    shopyo_dist_name = f"shopyo-{__version__}.tar.gz"
+    project_path = tmp_path / "foo"
+    # copy the shopyo dist to the test project path
+    copytree(dist_path, os.path.join(project_path, "dist"))
+    # change cwd to that of test project
+    os.chdir(project_path)
+    # create a new virtual environment(venv)
+    subprocess.check_call([sys.executable, "-m", "venv", "env"])
+    # store path for python and shopyo executable of venv for the case when OS
+    #  is Unix
+    python_env = os.path.join(os.getcwd(), "env", "bin", "python")
+    shopyo_env = os.path.join(os.getcwd(), "env", "bin", "shopyo")
+    # if OS is Windows, update the python and shopyo executable
+    if sys.platform == "win32":
+        python_env = os.path.join(os.getcwd(), "env", "Scripts", "python")
+        shopyo_env = os.path.join(os.getcwd(), "env", "Scripts", "shopyo")
+    # update pip of venv
+    subprocess.check_call(
+        [python_env, "-m", "pip", "install", "--upgrade", "pip"]
+    )
+    # install the shopyo package from dist added earlier
+    subprocess.check_call(
+        [
+            python_env,
+            "-m",
+            "pip",
+            "install",
+            os.path.join("dist", shopyo_dist_name)
+        ]
+    )
+    # run shopyo help command followed by new command
+    subprocess.check_call(["shopyo", "--help"])
+    subprocess.check_call([shopyo_env, "new"])
+    # change the cwd to the newly created shopyo project
+    os.chdir(os.path.join(project_path, "foo"))
+    # initialise the project
+    subprocess.check_call(
+        [shopyo_env, "initialise"]
+    )
+
+    assert os.path.exists("shopyo.db")
+    assert os.path.exists("migrations")

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ skip_missing_interpreters=true
 
 [testenv]
 changedir = shopyo
-deps = 
+deps =
     #setuptools
     -rrequirements/tests.txt
-commands = python -m pytest -v --tb=short {posargs} --cov  --cov-config={toxinidir}/.coveragerc --cov-branch --cov-report=term-missing
+commands =
+    python -m pytest -v  --basetemp={envtmpdir} --tb=short {posargs} --cov  --cov-config={toxinidir}/.coveragerc --cov-branch --cov-report=term-missing


### PR DESCRIPTION
* add a test to install the sdist for shopyo inside a temp folder, create a new venv, run shopyo's new command using subprocess and the venv's python and then run initialise.

* need to improve and add to the test later but with this all cli functions have some tests (previously was unable to test the `shopyo initialise`). The test is very slow and need to change it so it runs at the end later.

Resolves #13